### PR TITLE
Encode UTF-8 before joining output array

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -96,7 +96,11 @@ module Liquid
         end
       end
 
-      output.join
+      # Prevent the following error:
+      #   Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and UTF-8
+      utf8_ouput = output.map { |str| str.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "") }
+
+      utf8_ouput.join("")
     end
 
     private


### PR DESCRIPTION
https://projects.savedo.de/T1567

This patch is supposed to save us from errors like this one: http://10.150.10.173/apps/5603b7b969702d544f449801/problems/57b5d2e370726f104af12d01